### PR TITLE
Updating `importsim.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ $ mc init
 
 All of the scripts and commands below described below should be run under your **local project directory**.
 
-**Importing data from a simulation into the project directory**
+## Importing data from a simulation into the project directory
 
-The script <code>importsim.sh</code> copies data from a source directory where the simulation code and results files are located into a new target directory (also called simulation directory) whithin your project directory
+The script <code>importsim.sh</code> copies data from a source directory where the simulation code and data files are located into a new destination directory within your project directory.
 Usage
 ```
-$ ./importsim.sh [--move_vtk] <source directory> [--rename] <target directory>
+$ ./importsim.sh --copy=<ON/OFF> <source directory> <destination directory>
 ```
-This will copy most of the contents of <code>\<source directory\></code> into <code>\<target directory\></code> but orgazing the files the following way
+This will copy most of the contents of <code>\<source directory\></code> into <code>\<destination directory\></code>, organizing the files in the following way
 
 ├── **project directory** <br>
-           ├── **simulation directory** (target directory) <br>
+           ├── **simulation directory** (destination directory) <br>
                       ├── **code** <br>
                       ├── description.txt <br>
                       ├── observations.txt <br>
-                      ├── **results** <br>
+                      ├── **data** <br>
                                  ├── **images** <br>
                                  ├── **movies** <br>
                                  ├── **postprocess** <br>
@@ -41,11 +41,11 @@ This will copy most of the contents of <code>\<source directory\></code> into <c
 
 Options:
 
-<code>--move_vtk</code>    Moves vtu or vtk files from <code>\<source directory\></code> to <code>\<target directory\></code> instead of copying them. This might be convenient to save space locally.
+<code>--copy=<ON/OFF></code> Moves vtu, vtk, and pvtu files from <code>\<source directory\></code> to <code>\<destination directory\></code> instead of copying them.
 
-<code>--rename</code>      <code>\<target directory\></code>  If this option is not specified, the name of the <code>\<target directory\></code> will be the same as that of the <code>\<source directory\></code>.
+<code>\<destination directory></code> The destination directory. If this is left blank, the script will use the last folder of the <code>\<source directory\></code>.
 
-**Generating a simulation data/metadata file**
+## Generating a simulation data/metadata file
 
 The script <code>generate_yaml.py</code> parses the <code>parameters.prm</code> file, extracts key-value-type triples, and generates a yaml-type file with the data.
 Usage
@@ -54,7 +54,7 @@ $ python generate_yaml.py <simulation directory>
 ```
 The script requires the python packages <code>re</code>, <code>ruamel</code>, and <code>argparse</code> to run. The yaml file (<code>simlog.yaml</code>) will be generated in the <code>\<simulation directory\></code>.
 
-**Generating image frames and movies from the simulation results**
+## Generating image frames and movies from the simulation results
 
 The script <code>plot_series.py</code> uses the LLNL [visit](https://www.visitusers.org/index.php?title=Using_CLI) CLI to generate 2D pseudocolor frames (in png format)from a series of simulation's vtu/vtk files at different time increments. The user can specify the fields for which to generate the frames.
 Usage
@@ -71,7 +71,7 @@ $ ./make_movies.sh <var1> <var2> ... <simulation directory>
 ```
 The list of variables, \<var1\> \<var2\> ... \<varN\>, must only include variables for which a set of images (created using <code>plot_series.py</code>) already exist. 
 
-**Creating an ETL spreadsheet with simulation data**
+## Creating an ETL spreadsheet with simulation data
 
 The script <code>add_to_spreadsheet.py</code> does the following tasks:
 1) Extract the simulation data and metadata from the file <code>\<simulation directory\>/simlog.yaml</code>.

--- a/importsim.sh
+++ b/importsim.sh
@@ -135,8 +135,10 @@ if [ -z "$SRC_DIR" ]; then
 	exit 1
 fi
 if [ -z "$DST_DIR" ]; then
-	color_echo ${BAD} "No destination directory has been specified."
-	exit 1
+	# Get the last folder name from SRC_DIR
+	LAST_FOLDER=$(basename "${SRC_DIR}")
+	DST_DIR="./${LAST_FOLDER}"
+	color_echo ${INFO} "No destination specified, using relative path: ${DST_DIR}"
 fi
 
 # First expand any shell variables and home directory

--- a/importsim.sh
+++ b/importsim.sh
@@ -1,109 +1,195 @@
 #!/bin/bash
 
-# Function to check if a directory exists and ask for overwrite permission
-check_and_create_dir() {
-    local dir=$1
-    if [ -d "$dir" ]; then
-        read -p "Directory '$dir' already exists. Overwrite files? (y/n): " choice
-        case "$choice" in 
-            y|Y ) echo "Overwriting existing files...";;
-            n|N ) echo "Aborting."; exit 1;;
-            * ) echo "Invalid choice. Aborting."; exit 1;;
-        esac
-    else
-        mkdir -p "$dir"
-    fi
+#############################################################
+# Grab the date and start a global timer
+if builtin command -v gdate >/dev/null; then
+	DATE_CMD=$(which gdata)
+else
+	DATE_CMD=$(which date)
+fi
+TIC_GLOBAL="$(${DATE_CMD} +%s)"
+
+#############################################################
+# Various niceties that make the script look pretty
+
+# Colors
+BAD="\033[1;31m"
+GOOD="\033[1;32m"
+WARN="\033[1;35m"
+INFO="\033[1;34m"
+BOLD="\033[1m"
+
+# Color echo
+color_echo() {
+	COLOR=$1
+	shift
+	echo -e "${COLOR}$@\033[0m"
 }
 
-# Check if at least one argument is provided
-if [ $# -lt 1 ]; then
-    echo "No arguments supplied. Please provide an input directory."
-    exit 1
-fi
+# Exit with some useful information
+quit_if_fail() {
+	STATUS=$?
+	if [ ${STATUS} -ne 0 ]; then
+		color_echo ${BAD} "Failure with exit status:" ${STATUS}
+		color_echo ${BAD} "Exit message:" $1
+		exit ${STATUS}
+	fi
+}
 
-# Default values
-move_vtk=false
-rename_dir=""
+#############################################################
+# Parse command line inputs with default values below
+COPY_OUTPUT=ON
+SRC_DIR=""
+DST_DIR=""
 
-# Parse command-line flags
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --move_vtk) move_vtk=true; shift ;;
-        --rename)
-            if [[ -n "$2" && ! "$2" =~ ^-- ]]; then
-                rename_dir=$2
-                shift 2
-            else
-                echo "Error: --rename flag requires a directory name."
-                exit 1
-            fi
-            ;;
-        *) 
-            # The first non-flag argument is treated as the input directory
-            if [ -z "$input_dir" ]; then
-                input_dir=$1
-            else
-                echo "Unknown option: $1"
-                exit 1
-            fi
-            shift
-            ;;
-    esac
+while [ -n "$1" ]; do
+	input="$1"
+	case $input in
+
+	-h | --help)
+		echo "PRISMS-PF file organization for Materials Commons importing"
+		echo
+		echo "Usage: $0 [options]"
+		echo "Options:"
+		echo "  --copy=<ON/OFF> whether to copy or move *.vtu, *.pvtu, and *.vtk files (default = ${COPY_OUTPUT})"
+		echo "  -s <path>, --src=<path> the source directory."
+		echo "  -d <path>, --dst=<path> the target directory. (default = source directory)"
+		exit 0
+		;;
+
+	--copy=*)
+		COPY_OUTPUT="${input#*=}"
+		;;
+
+	-s)
+		shift
+		SRC_DIR="${1}"
+		;;
+	-src=*)
+		SRC_DIR="${param#*=}"
+		;;
+
+	-d)
+		shift
+		DST_DIR="${1}"
+		;;
+	-dst=*)
+		DST_DIR="${param#*=}"
+		;;
+
+	*)
+		echo "Invalid command line option <$input>. See -h for more information."
+		exit 2
+		;;
+
+	esac
+	shift
 done
 
-# Ensure input_dir is set
-if [ -z "$input_dir" ]; then
-    echo "Error: No input directory specified."
-    exit 1
-fi
-
-# Set locdir based on --rename flag or default to input_dir name
-if [ -n "$rename_dir" ]; then
-    locdir=$rename_dir
-else
-    locdir=${input_dir##*/}
-fi
-
-echo "Setting simulation directory: $locdir"
-
-code_dir="$locdir/code"
-results_dir="$locdir/results"
-vtk_files_dir="$results_dir/vtk"
-image_files_dir="$results_dir/images"
-movie_files_dir="$results_dir/movies"
-pp_files_dir="$results_dir/postprocess"
-
-# Creating directories with overwrite check
-check_and_create_dir "$locdir"
-mkdir -p "$code_dir" "$results_dir" "$vtk_files_dir" "$image_files_dir" "$movie_files_dir" "$pp_files_dir"
+#############################################################
+# Function to check if a directory exists and ask for overwrite permission
+check_and_create_dir() {
+	local dir=$1
+	if [ -d "$dir" ]; then
+		read -p "Directory '$dir' already exists. Overwrite files? (y/n): " choice
+		case "$choice" in
+		y | Y)
+			color_echo ${WARN} "Overwriting existing files..."
+			;;
+		n | N)
+			color_echo ${WARN} "Aborting..."
+			exit 1
+			;;
+		*)
+			color_echo ${BAD} "Invalid choice. Aborting..."
+			exit 1
+			;;
+		esac
+	else
+		mkdir -p "$dir"
+	fi
+}
 
 # Function to copy or move files with error handling
 copy_or_move_files() {
-    local src_ext=$1
-    local dest_dir=$2
-    local move_flag=$3
+	local SRC_REGEX=$1
+	local LOCAL_SRC=$2
+	local LOCAL_DST=$3
+	local COPY_FLAG=$4
 
-    if compgen -G "$input_dir/*.$src_ext" > /dev/null; then
-        if [ "$move_flag" = true ]; then
-            mv "$input_dir"/*."$src_ext" "$dest_dir"/
-        else
-            cp "$input_dir"/*."$src_ext" "$dest_dir"/
-        fi
-    else
-        echo "Warning: No .$src_ext files found in $input_dir"
-    fi
+	if compgen -G "${LOCAL_SRC}/${SRC_REGEX}" >/dev/null; then
+		if [ "${COPY_FLAG}" != "ON" ]; then
+			mv ${LOCAL_SRC}/${SRC_REGEX} "${LOCAL_DST}/"
+		else
+			cp ${LOCAL_SRC}/${SRC_REGEX} "${LOCAL_DST}/"
+		fi
+	else
+		echo
+		color_echo ${WARN} "No files matching '${SRC_REGEX}' found in ${LOCAL_SRC}"
+	fi
 }
 
+# Ensure SRC_DIR is set
+if [ -z "$SRC_DIR" ]; then
+	color_echo ${BAD} "No source directory has been specified."
+	exit 1
+fi
+
+# Print some info about SRC_DIR and DST_DIR
+BASE_DIR=$(pwd)
+if [ -z "$DST_DIR" ]; then
+	DST_DIR=${SRC_DIR}
+fi
+SRC_DIR=${BASE_DIR}/${SRC_DIR}
+DST_DIR=${BASE_DIR}/${DST_DIR}
+echo
+color_echo ${INFO} "Source directory: ${SRC_DIR}"
+color_echo ${INFO} "Destination directory: ${DST_DIR}"
+echo
+
+# Collect the various subfolders that we organize data into
+CODE_DIR="${DST_DIR}/code"
+RESULTS_DIR="${DST_DIR}/results"
+OUTPUT_DIR="${RESULTS_DIR}/vtk"
+IMAGE_DIR="${RESULTS_DIR}/images"
+MOVIE_DIR="${RESULTS_DIR}/movies"
+POSTPROCESS_DIR="${RESULTS_DIR}/postprocess"
+
+# Create the DST_DIR and ask if we have to overwrite files
+check_and_create_dir "${DST_DIR}"
+quit_if_fail "Failed to create destination directory."
+
+# Make the subfolders
+mkdir -p ${CODE_DIR} ${RESULTS_DIR} ${OUTPUT_DIR} ${IMAGE_DIR} ${MOVIE_DIR} ${POSTPROCESS_DIR}
+quit_if_fail "Failed to create subfolders in destination directory."
+
 # Organizing files
-copy_or_move_files "cc" "$code_dir" false
-copy_or_move_files "h" "$code_dir" false
-copy_or_move_files "prm" "$code_dir" false
-copy_or_move_files "vtk" "$vtk_files_dir" "$move_vtk"
-copy_or_move_files "vtu" "$vtk_files_dir" "$move_vtk"
-copy_or_move_files "md" "$locdir" false
+copy_or_move_files "*.cc" "${SRC_DIR}" "${CODE_DIR}" "ON"
+copy_or_move_files "*.h" "${SRC_DIR}" "${CODE_DIR}" "ON"
+copy_or_move_files "*.prm" "${SRC_DIR}" "${CODE_DIR}" "ON"
+copy_or_move_files "*.vtk" "${SRC_DIR}" "${OUTPUT_DIR}" "${COPY_OUTPUT}"
+copy_or_move_files "*.vtu" "${SRC_DIR}" "${OUTPUT_DIR}" "${COPY_OUTPUT}"
+copy_or_move_files "*.md" "${SRC_DIR}" "${DST_DIR}" "ON"
 
 # Special case: Handle single file copy for CMakeLists.txt and integratedFields.txt
-[ -f "$input_dir/CMakeLists.txt" ] && cp "$input_dir/CMakeLists.txt" "$code_dir/" || echo "Warning: CMakeLists.txt not found."
-[ -f "$input_dir/integratedFields.txt" ] && cp "$input_dir/integratedFields.txt" "$pp_files_dir/" || echo "Warning: integratedFields.txt not found."
+if [ -f "${SRC_DIR}/CMakeLists.txt" ]; then
+	cp "${SRC_DIR}/CMakeLists.txt" "${CODE_DIR}/"
+else
+	echo
+	color_echo ${WARN} "CMakeLists.txt not found."
+fi
 
-echo "File organization completed."
+if [ -f "${SRC_DIR}/integratedFields.txt" ]; then
+	cp "${SRC_DIR}/integratedFields.txt" "${POSTPROCESS_DIR}/"
+else
+	echo
+	color_echo ${WARN} "integratedFields.txt not found."
+fi
+
+# Stop the timer
+TOC_GLOBAL="$(($(${DATE_CMD} +%s) - TIC_GLOBAL))"
+
+# Summary
+echo
+color_echo ${GOOD} "File organization completed in $((TOC_GLOBAL)) seconds."
+echo


### PR DESCRIPTION
There's a lot of changes that happen to the file. To summarize the main ones:
- Added timer
- Added some helper functions the print with color (`color_echo`) and a little catch statement if certain bits of code fail (`quit_if_fail`). The latter function is unlikely to be super useful.
- Updated input parsing and added a help command (`./importsim.sh -h`)
- Renamed a bunch of variable names so we have a source directory and destination directory.

Right now this can run anywhere but it only handles relative paths to where you execute it. For example something like this is fine
```
~/materials_commons/mc_tools/importsim.sh -s alloySolidification_BaseOptimized_2D/ -d test/
```
But not this
```
~/materials_commons/mc_tools/importsim.sh -s ~/prisms/phaseField/alloySolidification_BaseOptimized_2D/ -d test/
```